### PR TITLE
correct maintainer last name spelling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R:
              email = "yongze.song@outlook.com", 
              role = c("aut", "cph"),
              comment = c(ORCID = "0000-0003-3420-9622")),
-      person(given = "Wenbo", family = "Lv",
+      person(given = "Wenbo", family = "Lyu",
              email = "lyu.geosocial@gmail.com", 
              role = c("aut", "cre"),
              comment = c(ORCID = "0009-0002-6003-3800"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # geosimilarity 3.9
 
+* Correct maintainer surname spelling from `Lv` to `Lyu` for pinyin compliance.
+
 # geosimilarity 3.8
 
 * No explicit change, only correct the package citation.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -22,7 +22,7 @@ navbar:
 authors:
   Yongze Song:
     href: https://yongzesong.com/
-  Wenbo Lv:
+  Wenbo Lyu:
     href: https://spatlyu.github.io/
 
 reference:


### PR DESCRIPTION
This PR updates the maintainer name from `Wenbo Lv` to `Wenbo Lyu` to align with my official passport spelling.

## Background

- **Chinese name**: 吕文博
- **Previous English name**: Wenbo Lv
- **Passport spelling**: Wenbo Lyu

The spelling `Lyu` is the standardized ASCII representation of the surname "吕" (Lü) used in official Chinese documents, including passports. This change ensures consistency across all official and academic records.

## Changes

- Updated maintainer name in `DESCRIPTION` file
- Updated author information in package metadata